### PR TITLE
Improve sensor polling

### DIFF
--- a/firmware/CameraWebServer/CameraWebServer.ino
+++ b/firmware/CameraWebServer/CameraWebServer.ino
@@ -15,6 +15,7 @@ DHT dht(DHTPIN, DHTTYPE);
 // 캐시된 센서 값과 갱신 시간
 float cachedHumidity   = NAN;
 float cachedTemperature = NAN;
+int   cachedFlame = -1;
 unsigned long dhtLastRead = 0;
 const unsigned long DHT_INTERVAL = 2000; // 2초
 
@@ -68,6 +69,7 @@ void setup() {
 
   // 불꽃 센서 입력 핀 설정
   pinMode(FLAME_PIN, INPUT);
+  cachedFlame = digitalRead(FLAME_PIN);
   
   // XCLK 주파수 설정 (20MHz)
   config.xclk_freq_hz = 20000000;
@@ -159,5 +161,7 @@ void loop() {
     }
     dhtLastRead = now;
   }
+  // flame 센서 값도 주기적으로 갱신한다.
+  cachedFlame = digitalRead(FLAME_PIN);
   delay(10);  // 다른 작업에 CPU를 양보
 }

--- a/firmware/CameraWebServer/app_httpd.cpp
+++ b/firmware/CameraWebServer/app_httpd.cpp
@@ -130,8 +130,8 @@ static esp_err_t bmp_handler(httpd_req_t *req) {
   free(buf);
 #if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
   uint64_t fr_end = esp_timer_get_time();   // 처리 종료 시간 기록
-#endif
   log_i("BMP: %llums, %uB", (uint64_t)((fr_end - fr_start) / 1000), buf_len);
+#endif
   return res;
 }
 
@@ -197,8 +197,8 @@ fb = esp_camera_fb_get();  //바로 프레임 캡처
   esp_camera_fb_return(fb);
 #if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
   int64_t fr_end = esp_timer_get_time();
-#endif
   log_i("JPG: %uB %ums", (uint32_t)(fb_len), (uint32_t)((fr_end - fr_start) / 1000));
+#endif
   return res;
 }
 
@@ -283,8 +283,8 @@ static esp_err_t stream_handler(httpd_req_t *req) {
     frame_time /= 1000;  // 밀리초 단위 변환
 #if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
     uint32_t avg_frame_time = ra_filter_run(&ra_filter, frame_time);
-#endif
     log_i("MJPG: %uB %ums (%.1ffps), AVG: %ums (%.1ffps)", (uint32_t)(_jpg_buf_len), (uint32_t)frame_time, 1000.0 / (uint32_t)frame_time, avg_frame_time, 1000.0 / avg_frame_time);
+#endif
   }
 
   return res;
@@ -677,6 +677,7 @@ static esp_err_t index_handler(httpd_req_t *req) {
 
 extern float cachedHumidity;
 extern float cachedTemperature;
+extern int   cachedFlame;
 
 static esp_err_t dht_handler(httpd_req_t *req) {
   if (isnan(cachedHumidity) || isnan(cachedTemperature)) {
@@ -692,7 +693,7 @@ static esp_err_t dht_handler(httpd_req_t *req) {
 }
 // 불꽃 센서 상태를 JSON으로 반환 
 static esp_err_t flame_handler(httpd_req_t *req) {
-  int flame = digitalRead(FLAME_PIN);  // 0: 불꽃 감지, 1: 정상
+  int flame = cachedFlame;  // 0: 불꽃 감지, 1: 정상
   char buf[32]; // JSON 포맷으로
   int len = snprintf(buf, sizeof(buf), "{\"flame\":%d}", flame);
   httpd_resp_set_type(req, "application/json");


### PR DESCRIPTION
## Summary
- cache flame sensor readings alongside DHT values
- wrap streaming frame logs with a log level check to reduce CPU use

## Testing
- `find backend -name '*.py' | xargs python3 -m py_compile` *(fails: unexpected character after line continuation character)*

------
https://chatgpt.com/codex/tasks/task_e_6848feb000d083238d0acf392d8552ec