### PR TITLE
Implement AI model prediction and analysis route

### DIFF
--- a/backend/app/routes/analyze.py
+++ b/backend/app/routes/analyze.py
@@ -1,10 +1,20 @@
 from flask import Blueprint, request, jsonify
 from ..auth import firebase_auth_required
+from ..services import ai_model
 
 analyze_bp = Blueprint('analyze', __name__)
 
 @analyze_bp.route('/api/analyze', methods=['POST'])
 @firebase_auth_required
 def analyze_image():
-    # Placeholder for model inference
-    return jsonify({'result': 'ok'})
+    """Analyze an uploaded image using the AI model."""
+    if 'image' not in request.files:
+        return jsonify({'error': 'No image file provided'}), 400
+
+    image_bytes = request.files['image'].read()
+    try:
+        result = ai_model.predict(image_bytes)
+    except Exception as exc:
+        return jsonify({'error': str(exc)}), 500
+
+    return jsonify({'result': result})

--- a/backend/app/services/ai_model.py
+++ b/backend/app/services/ai_model.py
@@ -1,0 +1,47 @@
+import os
+from io import BytesIO
+from typing import Any
+
+import torch
+from torchvision import transforms
+from PIL import Image
+
+# Path to the model weights
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+MODEL_PATH = os.path.join(BASE_DIR, 'models', 'model.pth')
+
+_model = None
+
+# Basic image preprocessing. This is intentionally simple since the exact
+# model architecture is unknown.
+_transform = transforms.Compose([
+    transforms.Resize((224, 224)),
+    transforms.ToTensor(),
+])
+
+def load_model() -> torch.nn.Module:
+    """Load the PyTorch model from disk if not already loaded."""
+    global _model
+    if _model is None:
+        if not os.path.exists(MODEL_PATH):
+            raise FileNotFoundError(f"Model file not found at {MODEL_PATH}")
+        _model = torch.load(MODEL_PATH, map_location=torch.device('cpu'))
+        _model.eval()
+    return _model
+
+
+def predict(image_bytes: bytes) -> Any:
+    """Run inference on the given image bytes and return the result."""
+    model = load_model()
+    image = Image.open(BytesIO(image_bytes)).convert('RGB')
+    tensor = _transform(image).unsqueeze(0)  # add batch dimension
+    with torch.no_grad():
+        output = model(tensor)
+
+    if isinstance(output, torch.Tensor):
+        return output.squeeze(0).tolist()
+    # Fallback for models that return non-Tensor outputs
+    try:
+        return output.tolist()
+    except AttributeError:
+        return output

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv
 firebase-admin
 torch
 torchvision
+Pillow


### PR DESCRIPTION
## Summary
- add PyTorch model loader and prediction helper
- enable `/api/analyze` endpoint to process uploaded images
- include Pillow in backend requirements

## Testing
- `python3 -m py_compile backend/app/services/ai_model.py backend/app/routes/analyze.py`

------
https://chatgpt.com/codex/tasks/task_e_6857018f13b08323aaa60f7ddfc7e6ee