### PR TITLE
Implement device management endpoints

### DIFF
--- a/backend/app/routes/device.py
+++ b/backend/app/routes/device.py
@@ -1,12 +1,48 @@
 from flask import Blueprint, jsonify, request
 from ..auth import firebase_auth_required
-from ..services.firebase_service import get_user_devices
+from ..services.firebase_service import (
+    get_user_devices,
+    add_user_device,
+    delete_user_device,
+)
 
 device_bp = Blueprint('device', __name__)
 
 @device_bp.route('/api/devices', methods=['GET'])
 @firebase_auth_required
 def list_devices():
-    uid = request.user['uid']
-    devices = get_user_devices(uid)
-    return jsonify({'devices': devices})
+    try:
+        uid = request.user['uid']
+        devices = get_user_devices(uid)
+        return jsonify({'devices': devices})
+    except Exception as exc:
+        return jsonify({'error': str(exc)}), 500
+
+
+@device_bp.route('/api/devices', methods=['POST'])
+@firebase_auth_required
+def add_device():
+    data = request.get_json(silent=True) or {}
+    device_id = data.get('device_id')
+    nickname = data.get('nickname')
+
+    if not device_id or not nickname:
+        return jsonify({'error': 'device_id and nickname required'}), 400
+
+    try:
+        uid = request.user['uid']
+        add_user_device(uid, device_id, nickname)
+        return jsonify({'message': 'Device added'}), 201
+    except Exception as exc:
+        return jsonify({'error': str(exc)}), 500
+
+
+@device_bp.route('/api/devices/<device_id>', methods=['DELETE'])
+@firebase_auth_required
+def remove_device(device_id):
+    try:
+        uid = request.user['uid']
+        delete_user_device(uid, device_id)
+        return jsonify({'message': 'Device deleted'})
+    except Exception as exc:
+        return jsonify({'error': str(exc)}), 500

--- a/backend/app/services/firebase_service.py
+++ b/backend/app/services/firebase_service.py
@@ -28,7 +28,36 @@ def verify_id_token(id_token: str):
 
 
 def get_user_devices(uid: str):
-    """Fetch devices belonging to a specific user UID."""
+    """Return a list of devices for the given user UID."""
     initialize_firebase()
-    docs = _db.collection('devices').where('owner', '==', uid).stream()
+    docs = (
+        _db.collection("users")
+        .document(uid)
+        .collection("devices")
+        .stream()
+    )
     return [doc.to_dict() for doc in docs]
+
+
+def add_user_device(uid: str, device_id: str, nickname: str) -> None:
+    """Add a device under the specified user."""
+    initialize_firebase()
+    doc_ref = (
+        _db.collection("users")
+        .document(uid)
+        .collection("devices")
+        .document(device_id)
+    )
+    doc_ref.set({"device_id": device_id, "nickname": nickname})
+
+
+def delete_user_device(uid: str, device_id: str) -> None:
+    """Delete a user's device by its ID."""
+    initialize_firebase()
+    doc_ref = (
+        _db.collection("users")
+        .document(uid)
+        .collection("devices")
+        .document(device_id)
+    )
+    doc_ref.delete()


### PR DESCRIPTION
## Summary
- manage devices for authenticated users via `/api/devices`
- support adding and deleting user devices
- update Firestore helpers for user device CRUD

## Testing
- `python -m py_compile backend/app/routes/device.py backend/app/services/firebase_service.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857189797588323aa9d3fdf2a9527c3