### PR TITLE
Add MJPEG stream proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Create a `.env` file in the repository root with the location of your Firebase s
 
 ```env
 GOOGLE_APPLICATION_CREDENTIALS=backend/firebase-adminsdk.json
+ESP32_STREAM_URL=http://<esp32-ip>/stream
 ```
 
 The backend loads this variable at start up.

--- a/backend/app/routes/stream.py
+++ b/backend/app/routes/stream.py
@@ -1,10 +1,40 @@
-from flask import Blueprint, jsonify
+"""Routes for streaming from ESP32-CAM."""
+
+import os
+import requests
+from flask import Blueprint, jsonify, Response, stream_with_context
 from ..auth import firebase_auth_required
 
-stream_bp = Blueprint('stream', __name__)
+stream_bp = Blueprint("stream", __name__)
 
-@stream_bp.route('/api/stream/<device_id>')
+
+@stream_bp.route("/api/stream-proxy", methods=["GET"])
 @firebase_auth_required
-def stream_device(device_id):
-    # Placeholder for streaming functionality
-    return jsonify({'device_id': device_id, 'stream_url': f'http://example.com/{device_id}'})
+def stream_proxy():
+    """Proxy MJPEG stream from ESP32-CAM to the client."""
+    stream_url = os.getenv("ESP32_STREAM_URL")
+    if not stream_url:
+        return jsonify({"error": "ESP32_STREAM_URL not set"}), 500
+
+    try:
+        upstream = requests.get(stream_url, stream=True)
+        upstream.raise_for_status()
+    except Exception as exc:  # requests.RequestException also covers HTTPError
+        return jsonify({"error": str(exc)}), 502
+
+    def generate():
+        try:
+            for chunk in upstream.iter_content(chunk_size=1024):
+                if chunk:
+                    yield chunk
+        finally:
+            upstream.close()
+
+    content_type = upstream.headers.get(
+        "Content-Type", "multipart/x-mixed-replace"
+    )
+
+    return Response(
+        stream_with_context(generate()),
+        content_type=content_type,
+    )


### PR DESCRIPTION
## Summary
- implement `/api/stream-proxy` blueprint route
- fetch stream URL from `ESP32_STREAM_URL`
- validate Firebase ID token
- add env variable in README

## Testing
- `pytest -q`
- `python -m py_compile backend/app/routes/stream.py`

------
https://chatgpt.com/codex/tasks/task_e_685719b2b2888323ace6c3098dcb7bf2