### PR TITLE
Fix stream proxy content type

### DIFF
--- a/backend/app/routes/stream.py
+++ b/backend/app/routes/stream.py
@@ -30,9 +30,9 @@ def stream_proxy():
         finally:
             upstream.close()
 
-    content_type = upstream.headers.get(
-        "Content-Type", "multipart/x-mixed-replace"
-    )
+    # The ESP32 sometimes omits the boundary parameter. Use a fixed MIME type
+    # expected by most MJPEG clients.
+    content_type = "multipart/x-mixed-replace; boundary=frame"
 
     return Response(
         stream_with_context(generate()),


### PR DESCRIPTION
## Summary
- fix stream proxy MIME type for MJPEG stream from ESP32-CAM

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68571db255d88323a05cf54d2822eacf