### PR TITLE
Enable logs screen to fetch data from backend

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -24,11 +24,13 @@ def create_app():
     from .routes.device import device_bp
     from .routes.stream import stream_bp
     from .routes.status import status_bp
+    from .routes.logs import logs_bp
 
     app.register_blueprint(analyze_bp)
     app.register_blueprint(device_bp)
     app.register_blueprint(stream_bp)
     app.register_blueprint(status_bp)
+    app.register_blueprint(logs_bp)
 
     # Enable Cross-Origin Resource Sharing
     CORS(app)

--- a/backend/app/routes/logs.py
+++ b/backend/app/routes/logs.py
@@ -1,0 +1,46 @@
+from flask import Blueprint, jsonify, request
+
+logs_bp = Blueprint('logs', __name__)
+
+# In-memory sample log data used for demonstration purposes
+_DEVICE_LOGS = {
+    'A': [
+        {'date': '2024/12/04', 'time': '15:25', 'temp': '24\u00b0C'},
+        {'date': '2025/01/04', 'time': '14:25', 'temp': '23\u00b0C'},
+        {'date': '2025/02/03', 'time': '01:21', 'temp': '32\u00b0C'},
+    ],
+    'B': [
+        {'date': '2025/02/03', 'time': '01:21', 'temp': '32\u00b0C'},
+    ],
+    'C': [],
+}
+
+
+@logs_bp.route('/api/logs', methods=['GET'])
+def list_logs():
+    """Return logs optionally filtered by device."""
+    device = request.args.get('device')
+    if device:
+        logs = [
+            {'device': device, **entry}
+            for entry in _DEVICE_LOGS.get(device, [])
+        ]
+    else:
+        logs = [
+            {'device': dev, **entry}
+            for dev, entries in _DEVICE_LOGS.items()
+            for entry in entries
+        ]
+    return jsonify({'logs': logs})
+
+
+@logs_bp.route('/api/logs', methods=['DELETE'])
+def delete_logs():
+    """Delete logs for a device or all logs."""
+    device = request.args.get('device')
+    if device:
+        _DEVICE_LOGS.get(device, []).clear()
+    else:
+        for entries in _DEVICE_LOGS.values():
+            entries.clear()
+    return jsonify({'message': 'Logs deleted'})

--- a/frontend/lib/core/services/logs_service.dart
+++ b/frontend/lib/core/services/logs_service.dart
@@ -1,0 +1,33 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+class LogsService {
+  LogsService._();
+  static final instance = LogsService._();
+
+  /// Base URL of the Flask backend
+  final String baseUrl = 'http://localhost:5000';
+
+  Future<List<Map<String, dynamic>>> fetchLogs({String? device}) async {
+    final uri = device != null
+        ? Uri.parse('$baseUrl/api/logs?device=$device')
+        : Uri.parse('$baseUrl/api/logs');
+    final response = await http.get(uri);
+    if (response.statusCode != 200) {
+      throw Exception('Failed to load logs: ${response.statusCode}');
+    }
+    final Map<String, dynamic> decoded = json.decode(response.body);
+    final List<dynamic> raw = decoded['logs'] as List<dynamic>;
+    return raw.cast<Map<String, dynamic>>();
+  }
+
+  Future<void> deleteLogs({String? device}) async {
+    final uri = device != null
+        ? Uri.parse('$baseUrl/api/logs?device=$device')
+        : Uri.parse('$baseUrl/api/logs');
+    final response = await http.delete(uri);
+    if (response.statusCode != 200) {
+      throw Exception('Failed to delete logs: ${response.statusCode}');
+    }
+  }
+}

--- a/frontend/lib/screens/logs.dart
+++ b/frontend/lib/screens/logs.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import '../core/services/device_service.dart';
+import '../core/services/logs_service.dart';
 
 /// 로그 조회 화면
 class LogsScreen extends StatefulWidget {
@@ -10,23 +12,45 @@ class LogsScreen extends StatefulWidget {
 }
 
 class _LogsScreenState extends State<LogsScreen> {
-  // ─── 더미 데이터 ───────────────────────────────────────────────────
-  final List<String> _devices = const ['A', 'B', 'C'];
-
-  final Map<String, List<Map<String, String>>> _deviceLogs = {
-    'A': [
-      {'date': '2024/12/04', 'time': '15:25', 'temp': '24°C'},
-      {'date': '2025/01/04', 'time': '14:25', 'temp': '23°C'},
-      {'date': '2025/02/03', 'time': '01:21', 'temp': '32°C'},
-    ],
-    'B': [
-      {'date': '2025/02/03', 'time': '01:21', 'temp': '32°C'},
-    ],
-    'C': [],
-  };
-  // ──────────────────────────────────────────────────────────────
-
+  List<String> _devices = [];
+  List<Map<String, dynamic>> _logs = [];
   String _selected = '전체';
+  bool _loading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadInitial();
+  }
+
+  Future<void> _loadInitial() async {
+    try {
+      final devices = await DeviceService.instance.fetchDevices();
+      setState(() {
+        _devices = devices.map((d) => d['device_id'] as String).toList();
+      });
+    } catch (_) {
+      // ignore errors fetching devices
+    }
+    await _loadLogs();
+  }
+
+  Future<void> _loadLogs() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final logs = await LogsService.instance
+          .fetchLogs(device: _selected == '전체' ? null : _selected);
+      setState(() => _logs = logs);
+    } catch (e) {
+      setState(() => _error = e.toString());
+    } finally {
+      setState(() => _loading = false);
+    }
+  }
 
   void _copyLogs() {
     final text = _logs
@@ -54,31 +78,28 @@ class _LogsScreenState extends State<LogsScreen> {
           ),
         ],
       ),
-    ).then((confirm) {
+    ).then((confirm) async {
       if (confirm == true) {
-        setState(() {
-          if (_selected == '전체') {
-            for (final k in _deviceLogs.keys) {
-              _deviceLogs[k]!.clear();
-            }
-          } else {
-            _deviceLogs[_selected]!.clear();
-          }
-        });
+        try {
+          await LogsService.instance
+              .deleteLogs(device: _selected == '전체' ? null : _selected);
+          await _loadLogs();
+        } catch (e) {
+          setState(() => _error = e.toString());
+        }
       }
     });
   }
 
-  List<Map<String, String>> get _logs => _selected == '전체'
-      ? _deviceLogs.entries
-          .expand((e) => e.value.map((m) => {...m, 'device': e.key}))
-          .toList()
-      : _deviceLogs[_selected]!
-          .map((m) => {...m, 'device': _selected})
-          .toList();
-
   @override
   Widget build(BuildContext context) {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_error != null) {
+      return Center(child: Text(_error!));
+    }
+
     return ListView(
       padding: const EdgeInsets.all(16),
       children: [
@@ -89,7 +110,10 @@ class _LogsScreenState extends State<LogsScreen> {
           items: ['전체', ..._devices]
               .map((d) => DropdownMenuItem(value: d, child: Text('단말기 $d')))
               .toList(),
-          onChanged: (v) => setState(() => _selected = v!),
+          onChanged: (v) {
+            setState(() => _selected = v!);
+            _loadLogs();
+          },
         ),
         const SizedBox(height: 16),
 


### PR DESCRIPTION
## Summary
- add `/api/logs` endpoint to backend
- register new blueprint in backend app factory
- create `LogsService` in Flutter frontend
- update `LogsScreen` to load logs via the API

## Testing
- `pytest`
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68574bcc1a1c8323821eedad3a43b7de