### PR TITLE
Implement server-based signup and login

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -23,3 +23,13 @@ Start the Flask app using:
 python run.py
 ```
 
+## User Authentication
+
+The backend now provides simple JSON based authentication. Use the following
+endpoints to register and log in users:
+
+* `POST /api/register` with JSON `{"email": "user@example.com", "password": "pw", "role": "일반"}`
+* `POST /api/login` with JSON `{"email": "user@example.com", "password": "pw"}`
+
+Successful login returns the user's role.
+

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -25,12 +25,14 @@ def create_app():
     from .routes.stream import stream_bp
     from .routes.status import status_bp
     from .routes.logs import logs_bp
+    from .routes.user_account import user_account_bp
 
     app.register_blueprint(analyze_bp)
     app.register_blueprint(device_bp)
     app.register_blueprint(stream_bp)
     app.register_blueprint(status_bp)
     app.register_blueprint(logs_bp)
+    app.register_blueprint(user_account_bp)
 
     # Enable Cross-Origin Resource Sharing
     CORS(app)

--- a/backend/app/routes/user_account.py
+++ b/backend/app/routes/user_account.py
@@ -1,0 +1,35 @@
+from flask import Blueprint, jsonify, request
+
+from ..services.user_service import add_user, authenticate_user
+
+user_account_bp = Blueprint('user_account', __name__)
+
+
+@user_account_bp.route('/api/register', methods=['POST'])
+def register():
+    data = request.get_json(silent=True) or {}
+    email = data.get('email')
+    password = data.get('password')
+    role = data.get('role', '일반')
+    if not email or not password:
+        return jsonify({'error': 'email and password required'}), 400
+    try:
+        add_user(email, password, role)
+        return jsonify({'message': 'User registered'}), 201
+    except ValueError as exc:
+        return jsonify({'error': str(exc)}), 400
+    except Exception as exc:
+        return jsonify({'error': str(exc)}), 500
+
+
+@user_account_bp.route('/api/login', methods=['POST'])
+def login():
+    data = request.get_json(silent=True) or {}
+    email = data.get('email')
+    password = data.get('password')
+    if not email or not password:
+        return jsonify({'error': 'email and password required'}), 400
+    user = authenticate_user(email, password)
+    if not user:
+        return jsonify({'error': 'Invalid credentials'}), 401
+    return jsonify({'message': 'Login successful', 'role': user['role']})

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -1,0 +1,41 @@
+import json
+import os
+
+# Path to users.json in backend directory
+_USERS_FILE = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', '..', 'users.json')
+)
+
+
+def _load_users() -> dict:
+    """Load users from the JSON file, creating it with defaults if missing."""
+    if not os.path.exists(_USERS_FILE):
+        users = {
+            'TUK@tukorea.ac.kr': {'pw': '123', 'role': '관리자'},
+            'Tino@tukorea.ac.kr': {'pw': '123', 'role': '일반'},
+        }
+        _save_users(users)
+        return users
+    with open(_USERS_FILE, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def _save_users(users: dict) -> None:
+    with open(_USERS_FILE, 'w', encoding='utf-8') as f:
+        json.dump(users, f, ensure_ascii=False, indent=2)
+
+
+def add_user(email: str, password: str, role: str) -> None:
+    users = _load_users()
+    if email in users:
+        raise ValueError('Email already exists')
+    users[email] = {'pw': password, 'role': role}
+    _save_users(users)
+
+
+def authenticate_user(email: str, password: str):
+    users = _load_users()
+    user = users.get(email)
+    if user and user.get('pw') == password:
+        return user
+    return None

--- a/backend/users.json
+++ b/backend/users.json
@@ -1,0 +1,4 @@
+{
+  "TUK@tukorea.ac.kr": {"pw": "123", "role": "관리자"},
+  "Tino@tukorea.ac.kr": {"pw": "123", "role": "일반"}
+}

--- a/frontend/lib/core/services/auth_service.dart
+++ b/frontend/lib/core/services/auth_service.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/foundation.dart';
+import 'dart:convert';
+import 'package:http/http.dart' as http;
 import 'user_store.dart';
 
 class AuthService with ChangeNotifier {
@@ -18,28 +20,39 @@ class AuthService with ChangeNotifier {
 
  // …위쪽 코드 동일…
   Future<String?> signUp(String email, String pw, String role) async {
-    if (UserStore.instance.contains(email)) {
-      return '이미 존재하는 이메일입니다';
+    final uri = Uri.parse('http://localhost:5000/api/register');
+    final response = await http.post(
+      uri,
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({'email': email, 'password': pw, 'role': role}),
+    );
+    if (response.statusCode == 201) {
+      notifyListeners();
+      return null;
     }
-    await UserStore.instance.addUser(email, pw, role);
-
-    notifyListeners();           // ⭐️ 신규: UI(UsersScreen) 갱신 트리거
-    return null;                 // null = 성공
+    final Map<String, dynamic> decoded = json.decode(response.body);
+    return decoded['error'] as String? ?? '가입 실패';
   }
 // …아래쪽 코드 동일…
 
 
   /// 로그인 (이메일·비밀번호 체크)
   Future<String?> signIn(String email, String pw) async {
-    final user = UserStore.instance.getUser(email);
-    if (user == null || user['pw'] != pw) {
-      return '이메일 또는 비밀번호가 일치하지 않습니다';
+    final uri = Uri.parse('http://localhost:5000/api/login');
+    final response = await http.post(
+      uri,
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({'email': email, 'password': pw}),
+    );
+    final Map<String, dynamic> decoded = json.decode(response.body);
+    if (response.statusCode == 200) {
+      _loggedIn = true;
+      _email = email;
+      _role = decoded['role'] as String?;
+      notifyListeners();
+      return null;
     }
-    _loggedIn = true;
-    _email = email;
-    _role = user['role'];
-    notifyListeners();
-    return null;
+    return decoded['error'] as String? ?? '로그인 실패';
   }
   
   Future<void> signOut() async {

--- a/frontend/lib/screens/dashboard.dart
+++ b/frontend/lib/screens/dashboard.dart
@@ -12,8 +12,8 @@ class DashboardScreen extends StatefulWidget {
 
 class _DashboardScreenState extends State<DashboardScreen> {
   bool _loading = true;
-  String? _error;
   Map<String, dynamic>? _status;
+  bool _serverOnline = false;
 
   // ─── 예시용 더미 데이터 ───────────────────────────────────────────────
   
@@ -39,9 +39,15 @@ class _DashboardScreenState extends State<DashboardScreen> {
   Future<void> _loadStatus() async {
     try {
       final data = await SystemStatusService.instance.fetchStatus();
-      setState(() => _status = data);
+      setState(() {
+        _status = data;
+        _serverOnline = true;
+      });
     } catch (e) {
-      setState(() => _error = e.toString());
+      setState(() {
+        _serverOnline = false;
+        _status = null;
+      });
     } finally {
       setState(() => _loading = false);
     }
@@ -52,14 +58,19 @@ class _DashboardScreenState extends State<DashboardScreen> {
     if (_loading) {
       return const Center(child: CircularProgressIndicator());
     }
-    if (_error != null) {
-      return Center(child: Text(_error!));
-    }
 
     final recentLogs = _deviceLogs.entries
         .expand((e) => e.value.map((m) => {...m, 'device': e.key}))
         .take(5)
         .toList();
+
+    final serverOnline = _serverOnline && _status?['server'] == 'online';
+    final devices = serverOnline
+        ? (_status?['devices'] as List<dynamic>? ?? [])
+            .cast<Map<String, dynamic>>()
+        : _deviceLogs.keys
+            .map((id) => {'device_id': id, 'status': 'offline'})
+            .toList();
 
     return Padding(
       padding: const EdgeInsets.all(16),
@@ -76,14 +87,16 @@ class _DashboardScreenState extends State<DashboardScreen> {
                       style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
                   const SizedBox(height: 12),
                   StatusRow(
-                      label: '서버 '
-                          '${_status?['server'] == 'online' ? '온라인' : '오프라인'}'),
+                      label: '서버 ' + (serverOnline ? '온라인' : '오프라인'),
+                      iconColor: serverOnline ? Colors.green : Colors.red),
                   const SizedBox(height: 12),
-                  ...(_status?['devices'] as List<dynamic>? ?? [])
-                      .cast<Map<String, dynamic>>()
-                      .map((d) => StatusRow(
-                          label:
-                              '단말기 ${d['device_id']} ${d['status'] == 'online' ? '온라인' : '오프라인'}')),
+                  ...devices.map((d) => StatusRow(
+                        label:
+                            '단말기 ${d['device_id']} ${d['status'] == 'online' ? '온라인' : '오프라인'}',
+                        iconColor: d['status'] == 'online'
+                            ? Colors.green
+                            : Colors.red,
+                      )),
                 ],
               ),
             ),


### PR DESCRIPTION
## Summary
- add simple JSON based user store in backend
- create `/api/register` and `/api/login` endpoints
- register new blueprint in Flask app
- update Flutter AuthService to call backend
- document new API endpoints
- show offline/online status in dashboard

## Testing
- `python -m py_compile backend/app/services/user_service.py backend/app/routes/user_account.py backend/app/__init__.py`
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68574fadf7c48323941c2dc9de6f7b0f