### PR TITLE
Add Firebase auth to Flutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,11 @@ flutter pub get
 flutter run
 ```
 
+### Firebase Authentication
+
+Some API endpoints require a Firebase ID token. The Flutter app now uses
+`firebase_auth` to sign in. Make sure to configure Firebase for your project and
+replace the placeholder values in `lib/firebase_options.dart` with your actual
+settings. After logging in, API requests automatically include the
+`Authorization: Bearer <token>` header.
+

--- a/frontend/lib/core/services/auth_service.dart
+++ b/frontend/lib/core/services/auth_service.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import 'package:firebase_auth/firebase_auth.dart';
 import 'user_store.dart';
 
 class AuthService with ChangeNotifier {
@@ -10,16 +11,25 @@ class AuthService with ChangeNotifier {
   bool _loggedIn = false;
   String? _email;               // 현재 로그인 이메일
   String? _role;                // '관리자' | '일반'
+  String? _idToken;             // Firebase ID 토큰
 
   bool get loggedIn => _loggedIn;
   String? get email => _email;
   String? get role => _role;
+  String? get idToken => _idToken;
 
   /// 앱 시작 시 UserStore 초기화
   Future<void> init() async => UserStore.instance.init();
 
  // …위쪽 코드 동일…
   Future<String?> signUp(String email, String pw, String role) async {
+    try {
+      await FirebaseAuth.instance
+          .createUserWithEmailAndPassword(email: email, password: pw);
+    } on FirebaseAuthException catch (e) {
+      return e.message ?? 'Firebase 가입 실패';
+    }
+
     final uri = Uri.parse('http://localhost:5000/api/register');
     final response = await http.post(
       uri,
@@ -36,8 +46,16 @@ class AuthService with ChangeNotifier {
 // …아래쪽 코드 동일…
 
 
-  /// 로그인 (이메일·비밀번호 체크)
+  /// 로그인 (Firebase 인증 후 백엔드 로그인)
   Future<String?> signIn(String email, String pw) async {
+    try {
+      await FirebaseAuth.instance
+          .signInWithEmailAndPassword(email: email, password: pw);
+      _idToken = await FirebaseAuth.instance.currentUser?.getIdToken();
+    } on FirebaseAuthException catch (e) {
+      return e.message ?? 'Firebase 로그인 실패';
+    }
+
     final uri = Uri.parse('http://localhost:5000/api/login');
     final response = await http.post(
       uri,
@@ -56,10 +74,20 @@ class AuthService with ChangeNotifier {
   }
   
   Future<void> signOut() async {
+    await FirebaseAuth.instance.signOut();
     _loggedIn = false;
     _email = null;
     _role = null;
+    _idToken = null;
     notifyListeners();
+  }
+
+  /// 현재 Firebase ID 토큰을 가져옵니다
+  Future<String?> getIdToken({bool forceRefresh = false}) async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return null;
+    _idToken = await user.getIdToken(forceRefresh);
+    return _idToken;
   }
 
   Future<void> deleteUser(String email) async {

--- a/frontend/lib/core/services/device_service.dart
+++ b/frontend/lib/core/services/device_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import 'auth_service.dart';
 
 class DeviceService {
   DeviceService._();
@@ -15,7 +16,10 @@ class DeviceService {
 
   Future<List<Map<String, dynamic>>> fetchDevices() async {
     final uri = Uri.parse('$baseUrl/api/devices');
-    final response = await http.get(uri);
+    final token = await AuthService.instance.getIdToken();
+    final response = await http.get(uri, headers: {
+      if (token != null) 'Authorization': 'Bearer $token'
+    });
     if (response.statusCode != 200) {
       throw Exception('Failed to load devices: ${response.statusCode}');
     }

--- a/frontend/lib/core/services/logs_service.dart
+++ b/frontend/lib/core/services/logs_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import 'auth_service.dart';
 
 class LogsService {
   LogsService._();
@@ -12,7 +13,10 @@ class LogsService {
     final uri = device != null
         ? Uri.parse('$baseUrl/api/logs?device=$device')
         : Uri.parse('$baseUrl/api/logs');
-    final response = await http.get(uri);
+    final token = await AuthService.instance.getIdToken();
+    final response = await http.get(uri, headers: {
+      if (token != null) 'Authorization': 'Bearer $token'
+    });
     if (response.statusCode != 200) {
       throw Exception('Failed to load logs: ${response.statusCode}');
     }
@@ -25,7 +29,10 @@ class LogsService {
     final uri = device != null
         ? Uri.parse('$baseUrl/api/logs?device=$device')
         : Uri.parse('$baseUrl/api/logs');
-    final response = await http.delete(uri);
+    final token = await AuthService.instance.getIdToken();
+    final response = await http.delete(uri, headers: {
+      if (token != null) 'Authorization': 'Bearer $token'
+    });
     if (response.statusCode != 200) {
       throw Exception('Failed to delete logs: ${response.statusCode}');
     }

--- a/frontend/lib/core/services/system_status_service.dart
+++ b/frontend/lib/core/services/system_status_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import 'auth_service.dart';
 
 class SystemStatusService {
   SystemStatusService._();
@@ -10,7 +11,10 @@ class SystemStatusService {
 
   Future<Map<String, dynamic>> fetchStatus() async {
     final uri = Uri.parse('$baseUrl/api/system-status');
-    final response = await http.get(uri);
+    final token = await AuthService.instance.getIdToken();
+    final response = await http.get(uri, headers: {
+      if (token != null) 'Authorization': 'Bearer $token'
+    });
     if (response.statusCode != 200) {
       throw Exception('Failed to load status: ${response.statusCode}');
     }

--- a/frontend/lib/firebase_options.dart
+++ b/frontend/lib/firebase_options.dart
@@ -1,0 +1,13 @@
+// TODO: Replace with actual Firebase options
+import 'package:firebase_core/firebase_core.dart' show FirebaseOptions;
+
+class DefaultFirebaseOptions {
+  static FirebaseOptions get currentPlatform {
+    return const FirebaseOptions(
+      apiKey: 'YOUR_API_KEY',
+      appId: 'YOUR_APP_ID',
+      messagingSenderId: 'YOUR_SENDER_ID',
+      projectId: 'YOUR_PROJECT_ID',
+    );
+  }
+}

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 import 'core/auth_gate.dart';
 import 'core/services/auth_service.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'firebase_options.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
   await AuthService.instance.init();   // ← UserStore 초기화
   runApp(const FireDetectionAdminApp());
 }

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -11,6 +11,8 @@ dependencies:
     sdk: flutter
   shared_preferences: ^2.2.2
   http: ^0.13.6
+  firebase_core: ^2.30.0
+  firebase_auth: ^4.18.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- integrate Firebase in Flutter AuthService
- include auth token in service requests
- initialize Firebase in main
- add example firebase_options.dart and update README
- add firebase packages to pubspec

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685783b2f0608323a3ed3935583b3d23